### PR TITLE
Add O-Line comparison dashboard example

### DIFF
--- a/app/components/o-line-dashboard.module.css
+++ b/app/components/o-line-dashboard.module.css
@@ -1,0 +1,19 @@
+.dashboard {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: center;
+}
+
+.table th {
+  background-color: #f2f2f2;
+}

--- a/app/components/o-line-dashboard.tsx
+++ b/app/components/o-line-dashboard.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import React from "react";
+import styles from "./o-line-dashboard.module.css";
+
+export interface Player {
+  name: string;
+  team: string;
+  passBlockWinRate: number; // pass protection success percentage
+  runBlockWinRate: number; // run blocking success percentage
+  pressuresAllowed: number;
+  sacksAllowed: number;
+}
+
+export type MetricKey =
+  | "passBlockWinRate"
+  | "runBlockWinRate"
+  | "pressuresAllowed"
+  | "sacksAllowed";
+
+export interface Metric {
+  key: MetricKey;
+  label: string;
+  isPercentage?: boolean;
+}
+
+const defaultMetrics: Metric[] = [
+  { key: "passBlockWinRate", label: "Pass Block Win %", isPercentage: true },
+  { key: "runBlockWinRate", label: "Run Block Win %", isPercentage: true },
+  { key: "pressuresAllowed", label: "Pressures Allowed" },
+  { key: "sacksAllowed", label: "Sacks Allowed" },
+];
+
+const samplePlayers: Player[] = [
+  {
+    name: "Trent Williams",
+    team: "SF",
+    passBlockWinRate: 92,
+    runBlockWinRate: 89,
+    pressuresAllowed: 12,
+    sacksAllowed: 1,
+  },
+  {
+    name: "Lane Johnson",
+    team: "PHI",
+    passBlockWinRate: 91,
+    runBlockWinRate: 87,
+    pressuresAllowed: 16,
+    sacksAllowed: 0,
+  },
+  {
+    name: "Zack Martin",
+    team: "DAL",
+    passBlockWinRate: 88,
+    runBlockWinRate: 90,
+    pressuresAllowed: 15,
+    sacksAllowed: 2,
+  },
+  {
+    name: "Quenton Nelson",
+    team: "IND",
+    passBlockWinRate: 87,
+    runBlockWinRate: 85,
+    pressuresAllowed: 20,
+    sacksAllowed: 3,
+  },
+  {
+    name: "Andrew Thomas",
+    team: "NYG",
+    passBlockWinRate: 89,
+    runBlockWinRate: 84,
+    pressuresAllowed: 18,
+    sacksAllowed: 4,
+  },
+];
+
+interface DashboardProps {
+  players?: Player[];
+  metrics?: Metric[];
+}
+
+const OLineDashboard: React.FC<DashboardProps> = ({
+  players = samplePlayers,
+  metrics = defaultMetrics,
+}) => {
+  return (
+    <div className={styles.dashboard}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Player</th>
+            <th>Team</th>
+            {metrics.map((metric) => (
+              <th key={metric.key}>{metric.label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {players.map((player) => (
+            <tr key={player.name}>
+              <td>{player.name}</td>
+              <td>{player.team}</td>
+              {metrics.map((metric) => {
+                const value = player[metric.key];
+                return (
+                  <td key={metric.key}>
+                    {metric.isPercentage ? `${value}%` : value}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default OLineDashboard;

--- a/app/examples/o-line/page.module.css
+++ b/app/examples/o-line/page.module.css
@@ -1,0 +1,13 @@
+.main {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: white;
+}
+
+.container {
+  max-width: 900px;
+  width: 100%;
+  padding: 20px;
+}

--- a/app/examples/o-line/page.tsx
+++ b/app/examples/o-line/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import React from "react";
+import styles from "./page.module.css";
+import OLineDashboard from "../../components/o-line-dashboard";
+
+const OLinePage = () => {
+  return (
+    <main className={styles.main}>
+      <div className={styles.container}>
+        <OLineDashboard />
+      </div>
+    </main>
+  );
+};
+
+export default OLinePage;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ const Home = () => {
     "Basic chat": "basic-chat",
     "Function calling": "function-calling",
     "File search": "file-search",
+    "O-Line Comparison": "o-line",
     All: "all",
   };
 


### PR DESCRIPTION
## Summary
- create an O-Line dashboard component written in TypeScript
- add sample players and metrics arrays
- add a new example page that renders the dashboard
- list `O-Line Comparison` on the home page for quick access

## Testing
- `npm run lint` *(fails: project prompts for ESLint setup)*
- `npm run build` *(fails: cannot fetch Inter font from Google)*