### PR TITLE
Add sports API integration guide

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -1,0 +1,20 @@
+# Example Integration: Sportsdata.io API
+
+The [Sportsdata.io](https://sportsdata.io/) service offers comprehensive sports statistics for several leagues. Below is a short walkthrough of how you can start using their football data API.
+
+## 1. Sign up and obtain an API key
+1. Visit the [Sportsdata.io registration page](https://sportsdata.io/developers/register).
+2. Create an account or log in. After registration, navigate to your profile dashboard.
+3. Choose the desired sport and subscription plan. The dashboard will display your **API key**, which is required for all requests.
+
+## 2. Example request
+Sportsdata.io uses standard RESTful endpoints. Here's a sample request to fetch NFL players using `curl`:
+```bash
+curl -G "https://api.sportsdata.io/v3/nfl/scores/json/Players" \
+  -d "key=YOUR_API_KEY"
+```
+Replace `YOUR_API_KEY` with the key from your dashboard. The response will be a JSON array containing player information.
+
+## 3. Notes
+- **Rate limits** and allowed endpoints depend on your subscription plan. Review the [Sportsdata.io documentation](https://sportsdata.io/developers) for details.
+- Additional parameters can filter the results (e.g., by season or team). Refer to the docs for the specific endpoint.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ The main logic for chat will be found in the `Chat` component in `app/components
 ## Feedback
 
 Let us know if you have any thoughts, questions, or feedback in [this form](https://docs.google.com/forms/d/e/1FAIpQLScn_RSBryMXCZjCyWV4_ebctksVvQYWkrq90iN21l1HLv3kPg/viewform?usp=sf_link)!
+
+## Sports API Integration Example
+
+For a quick example of integrating a third-party sports data service, see [INTEGRATION_GUIDE.md](./INTEGRATION_GUIDE.md). It outlines how to obtain an API key from Sportsdata.io and make a sample request.


### PR DESCRIPTION
## Summary
- document example integration using Sportsdata.io API with step-by-step instructions
- link to the new guide from README

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: cannot fetch fonts due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685beafa75108330885e6a1c14143527