### PR TITLE
Add Gemini API demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ OPENAI_API_KEY="sk-123..."
 # (optional) Create an OpenAI Assistant at https://platform.openai.com/assistants.
 # IMPORTANT! Be sure to enable file search and code interpreter tools.
 OPENAI_ASSISTANT_ID="123..."
+
+# Gemini API key for /api/gemini route
+GEMINI_API_KEY="ai-123..."
+

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ git clone https://github.com/openai/openai-assistants-quickstart.git
 cd openai-assistants-quickstart
 ```
 
-### 2. Set your [OpenAI API key](https://platform.openai.com/api-keys)
+### 2. Set your API keys
 
 ```shell
 export OPENAI_API_KEY="sk_..."
+export GEMINI_API_KEY="ai_..."
 ```
 
 (or in `.env.example` and rename it to `.env`).
@@ -40,7 +41,7 @@ npm run dev
 
 You can deploy this project to Vercel or any other platform that supports Next.js.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-assistants-quickstart&env=OPENAI_API_KEY,OPENAI_ASSISTANT_ID&envDescription=API%20Keys%20and%20Instructions&envLink=https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-assistants-quickstart%2Fblob%2Fmain%2F.env.example)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-assistants-quickstart&env=OPENAI_API_KEY,OPENAI_ASSISTANT_ID,GEMINI_API_KEY&envDescription=API%20Keys%20and%20Instructions&envLink=https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-assistants-quickstart%2Fblob%2Fmain%2F.env.example)
 
 ## Overview
 

--- a/app/api/gemini/route.ts
+++ b/app/api/gemini/route.ts
@@ -1,0 +1,53 @@
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const { prompt } = await request.json();
+
+  if (!prompt) {
+    return new Response(JSON.stringify({ error: "Prompt required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    return new Response(
+      JSON.stringify({ error: "GEMINI_API_KEY is not set" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const apiUrl =
+    "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=" +
+    apiKey;
+
+  const body = {
+    contents: [{ role: "user", parts: [{ text: prompt }] }],
+  };
+
+  const resp = await fetch(apiUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    return new Response(text, {
+      status: resp.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const data = await resp.json();
+  const text =
+    data?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+
+  return new Response(JSON.stringify({ text }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/app/examples/gemini/page.module.css
+++ b/app/examples/gemini/page.module.css
@@ -1,0 +1,31 @@
+.main {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: white;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 700px;
+  width: 100%;
+}
+
+textarea {
+  width: 100%;
+  height: 150px;
+}
+
+button {
+  padding: 8px 16px;
+}
+
+.output {
+  white-space: pre-wrap;
+  background-color: #f0f0f0;
+  padding: 12px;
+  border-radius: 8px;
+}

--- a/app/examples/gemini/page.tsx
+++ b/app/examples/gemini/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React, { useState } from "react";
+import styles from "./page.module.css";
+
+const GeminiDemo = () => {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function submit() {
+    if (!input.trim()) return;
+    setLoading(true);
+    setOutput(null);
+    const res = await fetch("/api/gemini", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: input }),
+    });
+    setLoading(false);
+    if (!res.ok) {
+      const err = await res.text();
+      setOutput(`Error: ${err}`);
+      return;
+    }
+    const data = await res.json();
+    setOutput(data.text);
+  }
+
+  return (
+    <main className={styles.main}>
+      <div className={styles.container}>
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Enter a prompt"
+        />
+        <button onClick={submit} disabled={loading}>
+          {loading ? "Loading..." : "Ask Gemini"}
+        </button>
+        {output && <div className={styles.output}>{output}</div>}
+      </div>
+    </main>
+  );
+};
+
+export default GeminiDemo;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ const Home = () => {
     "Basic chat": "basic-chat",
     "Function calling": "function-calling",
     "File search": "file-search",
+    "Gemini demo": "gemini",
     All: "all",
   };
 


### PR DESCRIPTION
## Summary
- add `/api/gemini` server route that calls Gemini API using `GEMINI_API_KEY`
- document new env var in README
- create Gemini demo example page
- list Gemini demo on homepage

## Testing
- `npx next lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_685ff9d8b7288330b05086f2901268df