### PR TITLE
Add Blaze Intelligence sports coverage pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A quick-start template using the OpenAI [Assistants API](https://platform.openai
 <br/>
 ![OpenAI Assistants API Quickstart](https://github.com/openai/openai-assistants-quickstart/assets/27232/755e85e9-3ea4-421f-b202-3b0c435ea270)
 
+## Blaze Intelligence
+
+This repository now includes a starter portal for **Blaze Intelligence**, expanding research across college sports, NIL, MLB, NFL, NBA, high school football, and Perfect Game baseball.
+
 ## Quickstart Setup
 
 ### 1. Clone repo

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,25 +2,16 @@
 
 import React from "react";
 import styles from "./page.module.css";
+import { sportsCategories } from "./sports/categories";
 
 const Home = () => {
-  const categories = {
-    "Basic chat": "basic-chat",
-    "Function calling": "function-calling",
-    "File search": "file-search",
-    "Film study": "film-study",
-    All: "all",
-  };
-
   return (
     <main className={styles.main}>
-      <div className={styles.title}>
-        Explore sample apps built with Assistants API
-      </div>
+      <div className={styles.title}>Blaze Intelligence Research Portal</div>
       <div className={styles.container}>
-        {Object.entries(categories).map(([name, url]) => (
-          <a key={name} className={styles.category} href={`/examples/${url}`}>
-            {name}
+        {sportsCategories.map((cat) => (
+          <a key={cat.id} className={styles.category} href={`/sports/${cat.id}`}>
+            {cat.name}
           </a>
         ))}
       </div>

--- a/app/sports/[category]/page.tsx
+++ b/app/sports/[category]/page.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { sportsCategories } from "../categories";
+
+type Props = {
+  params: { category: string };
+};
+
+const SportPage = ({ params }: Props) => {
+  const category = sportsCategories.find((c) => c.id === params.category);
+  if (!category) {
+    return <div>Unknown category: {params.category}</div>;
+  }
+  return (
+    <main style={{ padding: 20 }}>
+      <h1>{category.name}</h1>
+      <p>
+        Research and content for {category.name} will appear here as Blaze Intelligence expands its
+        coverage.
+      </p>
+    </main>
+  );
+};
+
+export default SportPage;

--- a/app/sports/categories.ts
+++ b/app/sports/categories.ts
@@ -1,0 +1,14 @@
+export interface SportCategory {
+  id: string;
+  name: string;
+}
+
+export const sportsCategories: SportCategory[] = [
+  { id: "college", name: "College Sports" },
+  { id: "nil", name: "Name, Image, Likeness" },
+  { id: "mlb", name: "Major League Baseball" },
+  { id: "nfl", name: "National Football League" },
+  { id: "nba", name: "National Basketball Association" },
+  { id: "high-school-football", name: "High School Football" },
+  { id: "perfect-game", name: "Perfect Game Baseball" }
+];


### PR DESCRIPTION
## Summary
- Expand homepage into Blaze Intelligence research portal
- List major sports categories and dynamic placeholder pages
- Document new Blaze Intelligence scope in README

## Testing
- `npm run build` *(fails: Failed to fetch font `Inter` due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68a1be7ff8388330a675a96d1ba52131