### PR TITLE
Add scoreboard utility and dynamic sport pages

### DIFF
--- a/app/api/sports/route.ts
+++ b/app/api/sports/route.ts
@@ -1,6 +1,8 @@
 export const runtime = "nodejs";
 
-const SPORTS_ENDPOINTS: Record<string, {sport: string; league: string}> = {
+import { fetchScoreboard } from "@/app/utils/scoreboard";
+
+const SPORTS_ENDPOINTS: Record<string, { sport: string; league: string }> = {
   mlb: { sport: "baseball", league: "mlb" },
   nfl: { sport: "football", league: "nfl" },
   nba: { sport: "basketball", league: "nba" },
@@ -8,21 +10,11 @@ const SPORTS_ENDPOINTS: Record<string, {sport: string; league: string}> = {
   collegeBaseball: { sport: "baseball", league: "college-baseball" },
 };
 
-async function getScoreboard(sport: string, league: string) {
-  const date = new Date().toISOString().split("T")[0].replace(/-/g, "");
-  const url = `https://site.web.api.espn.com/apis/v2/sports/${sport}/${league}/scoreboard?dates=${date}`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`Failed to fetch scoreboard for ${sport}/${league}`);
-  }
-  return res.json();
-}
-
 export async function GET() {
   const results: Record<string, unknown> = {};
   for (const [key, { sport, league }] of Object.entries(SPORTS_ENDPOINTS)) {
     try {
-      results[key] = await getScoreboard(sport, league);
+      results[key] = await fetchScoreboard(sport, league);
     } catch (err) {
       results[key] = { error: (err as Error).message };
     }

--- a/app/sports/[category]/page.tsx
+++ b/app/sports/[category]/page.tsx
@@ -1,22 +1,45 @@
 import React from "react";
 import { sportsCategories } from "../categories";
+import { fetchScoreboard } from "@/app/utils/scoreboard";
 
 type Props = {
   params: { category: string };
 };
 
-const SportPage = ({ params }: Props) => {
+const SCOREBOARD_MAP: Record<string, { sport: string; league: string }> = {
+  mlb: { sport: "baseball", league: "mlb" },
+  nfl: { sport: "football", league: "nfl" },
+  nba: { sport: "basketball", league: "nba" },
+  college: { sport: "football", league: "college-football" },
+};
+
+const SportPage = async ({ params }: Props) => {
   const category = sportsCategories.find((c) => c.id === params.category);
   if (!category) {
     return <div>Unknown category: {params.category}</div>;
   }
+
+  let scoreboard: unknown = null;
+  const endpoint = SCOREBOARD_MAP[params.category];
+  if (endpoint) {
+    try {
+      scoreboard = await fetchScoreboard(endpoint.sport, endpoint.league);
+    } catch (err) {
+      scoreboard = { error: (err as Error).message };
+    }
+  }
+
   return (
     <main style={{ padding: 20 }}>
       <h1>{category.name}</h1>
-      <p>
-        Research and content for {category.name} will appear here as Blaze Intelligence expands its
-        coverage.
-      </p>
+      {scoreboard ? (
+        <pre style={{ whiteSpace: "pre-wrap" }}>{JSON.stringify(scoreboard, null, 2)}</pre>
+      ) : (
+        <p>
+          Research and content for {category.name} will appear here as Blaze Intelligence expands its
+          coverage.
+        </p>
+      )}
     </main>
   );
 };

--- a/app/utils/scoreboard.ts
+++ b/app/utils/scoreboard.ts
@@ -1,0 +1,9 @@
+export async function fetchScoreboard(sport: string, league: string) {
+  const date = new Date().toISOString().split("T")[0].replace(/-/g, "");
+  const url = `https://site.web.api.espn.com/apis/v2/sports/${sport}/${league}/scoreboard?dates=${date}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch scoreboard for ${sport}/${league}`);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add shared ESPN scoreboard fetch helper
- update sports API route to reuse shared helper
- show scoreboard data on sport category pages when available

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68a27a64e71c833088ed4e1139f5e179