### PR TITLE
feat: add three.js minecraft experience

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/minecraft/page.module.css
+++ b/app/minecraft/page.module.css
@@ -1,0 +1,157 @@
+.page {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  background: radial-gradient(circle at top, #9fd5ff 0%, #87ceeb 45%, #5fb3ff 100%);
+}
+
+.canvasRoot {
+  position: absolute;
+  inset: 0;
+}
+
+.hud {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+  color: #ffffff;
+}
+
+.crosshair {
+  font-size: 28px;
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+}
+
+.inventory {
+  position: absolute;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 18px;
+  background: rgba(16, 24, 34, 0.7);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.3);
+  pointer-events: auto;
+  backdrop-filter: blur(6px);
+}
+
+.slotButton {
+  width: 56px;
+  height: 56px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #fdfdfd;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.slotButton:focus-visible {
+  outline: 2px solid #ffda6a;
+  outline-offset: 2px;
+}
+
+.slotButton:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.65);
+}
+
+.slotSelected {
+  border-color: #ffda6a;
+  box-shadow: 0 0 14px rgba(255, 218, 106, 0.7);
+}
+
+.blockSwatch {
+  width: 28px;
+  height: 18px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.instructions {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: min(540px, calc(100% - 40px));
+  background: rgba(16, 24, 34, 0.85);
+  padding: 16px 20px;
+  border-radius: 16px;
+  text-align: center;
+  font-size: 14px;
+  line-height: 1.5;
+  pointer-events: auto;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.instructions h1 {
+  font-size: 20px;
+  margin-bottom: 8px;
+  letter-spacing: 0.03em;
+}
+
+.instructions p {
+  margin-bottom: 8px;
+  color: #d8ecff;
+}
+
+.instructions ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 6px 18px;
+  color: #eef6ff;
+}
+
+.instructionsHidden {
+  opacity: 0;
+  transform: translate(-50%, -8px);
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.errorBanner {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: min(520px, calc(100% - 32px));
+  background: rgba(176, 32, 32, 0.9);
+  color: #fff3f3;
+  padding: 14px 18px;
+  border-radius: 14px;
+  text-align: center;
+  font-size: 14px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+  pointer-events: auto;
+}
+
+@media (max-width: 720px) {
+  .slotButton {
+    width: 48px;
+    height: 48px;
+    font-size: 10px;
+  }
+
+  .instructions {
+    font-size: 13px;
+  }
+}

--- a/app/minecraft/page.tsx
+++ b/app/minecraft/page.tsx
@@ -1,0 +1,893 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  BufferGeometry,
+  Intersection,
+  Material,
+  Mesh,
+  Object3D,
+  Texture,
+} from "three";
+import styles from "./page.module.css";
+import type { PointerLockControls as PointerLockControlsType } from "three/examples/jsm/controls/PointerLockControls";
+
+type ThreeModule = typeof import("three");
+type PointerLockControlsModule = typeof import("three/examples/jsm/controls/PointerLockControls");
+
+type BlockType =
+  | "grass"
+  | "dirt"
+  | "stone"
+  | "sand"
+  | "water"
+  | "log"
+  | "leaves";
+
+const BLOCK_LABELS: Record<BlockType, string> = {
+  grass: "Grass",
+  dirt: "Dirt",
+  stone: "Stone",
+  sand: "Sand",
+  water: "Water",
+  log: "Wood",
+  leaves: "Leaves",
+};
+
+const BLOCK_SWATCHES: Record<BlockType, string> = {
+  grass: "linear-gradient(180deg, #4caf50 0%, #3e872f 60%, #3a5f26 100%)",
+  dirt: "linear-gradient(180deg, #7a5030 0%, #5c3a20 100%)",
+  stone: "linear-gradient(180deg, #9ea4a8 0%, #72787c 100%)",
+  sand: "linear-gradient(180deg, #f1db95 0%, #d7c179 100%)",
+  water: "linear-gradient(180deg, rgba(64, 142, 255, 0.9) 0%, rgba(32, 82, 190, 0.9) 100%)",
+  log: "linear-gradient(180deg, #a0703c 0%, #6d4a24 100%)",
+  leaves: "linear-gradient(180deg, rgba(90, 156, 60, 0.95) 0%, rgba(54, 116, 38, 0.95) 100%)",
+};
+
+const SELECTABLE_BLOCKS: BlockType[] = [
+  "grass",
+  "dirt",
+  "stone",
+  "sand",
+  "log",
+  "leaves",
+  "water",
+];
+
+const THREE_MODULE_URL =
+  "https://unpkg.com/three@0.160.0/build/three.module.js?module";
+const POINTER_LOCK_URL =
+  "https://unpkg.com/three@0.160.0/examples/jsm/controls/PointerLockControls.js?module";
+
+let cachedThreePromise: Promise<ThreeModule> | null = null;
+let cachedPointerLockPromise: Promise<PointerLockControlsModule> | null = null;
+
+const loadThree = async (): Promise<ThreeModule> => {
+  if (!cachedThreePromise) {
+    cachedThreePromise = import(
+      /* webpackIgnore: true */ THREE_MODULE_URL
+    ) as Promise<ThreeModule>;
+  }
+  return cachedThreePromise;
+};
+
+const loadPointerLockControls = async (): Promise<PointerLockControlsModule> => {
+  if (!cachedPointerLockPromise) {
+    cachedPointerLockPromise = import(
+      /* webpackIgnore: true */ POINTER_LOCK_URL
+    ) as Promise<PointerLockControlsModule>;
+  }
+  return cachedPointerLockPromise;
+};
+
+const solidBlocks: ReadonlySet<BlockType> = new Set<BlockType>([
+  "grass",
+  "dirt",
+  "stone",
+  "sand",
+  "log",
+  "leaves",
+]);
+
+const SEA_LEVEL = 2;
+const BASE_DEPTH = -2;
+const WORLD_RADIUS = 28;
+const PLAYER_EYE_HEIGHT = 1.7;
+const MOVE_SPEED = 28;
+const DECELERATION = 12;
+const MAX_BUILD_HEIGHT = 48;
+
+const getBlockKey = (x: number, y: number, z: number): string => `${x}|${y}|${z}`;
+
+const MinecraftPage = () => {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const selectedBlockRef = useRef<BlockType>(SELECTABLE_BLOCKS[0]);
+  const [selectedBlock, setSelectedBlock] = useState<BlockType>(
+    SELECTABLE_BLOCKS[0]
+  );
+  const [isLocked, setIsLocked] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setBlockType = useCallback((type: BlockType) => {
+    selectedBlockRef.current = type;
+    setSelectedBlock(type);
+  }, []);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) {
+      return;
+    }
+
+    let active = true;
+    let cleanup: (() => void) | undefined;
+
+    const setup = async () => {
+      try {
+        setError(null);
+        const [THREE, pointerLockModule] = await Promise.all([
+          loadThree(),
+          loadPointerLockControls(),
+        ]);
+
+        if (!active || !mountRef.current) {
+          return;
+        }
+
+        if (typeof document === "undefined" || !("pointerLockElement" in document)) {
+          setError("Pointer lock is not supported in this environment.");
+          return;
+        }
+
+        const mountElement = mountRef.current;
+        const scene = new THREE.Scene();
+        scene.background = new THREE.Color(0x87ceeb);
+        scene.fog = new THREE.Fog(0x87ceeb, 60, 220);
+
+        const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+        renderer.outputColorSpace = THREE.SRGBColorSpace;
+        renderer.setPixelRatio(window.devicePixelRatio);
+        renderer.setSize(mountElement.clientWidth, mountElement.clientHeight, false);
+        renderer.domElement.style.width = "100%";
+        renderer.domElement.style.height = "100%";
+        renderer.domElement.style.display = "block";
+        renderer.domElement.style.cursor = "crosshair";
+        renderer.domElement.style.touchAction = "none";
+        renderer.domElement.tabIndex = 0;
+        mountElement.appendChild(renderer.domElement);
+
+        const camera = new THREE.PerspectiveCamera(
+          70,
+          mountElement.clientWidth / mountElement.clientHeight,
+          0.1,
+          600
+        );
+
+        const controls: PointerLockControlsType = new pointerLockModule.PointerLockControls(
+          camera,
+          renderer.domElement
+        );
+        controls.connect();
+        scene.add(controls.getObject());
+
+        const clock = new THREE.Clock();
+        const pointer = new THREE.Vector2(0, 0);
+        const raycaster = new THREE.Raycaster();
+        const velocity = new THREE.Vector3();
+        const direction = new THREE.Vector3();
+        const previousPosition = new THREE.Vector3();
+        let maxWorldHeight = 16;
+
+        const texturesToDispose: Texture[] = [];
+        const materialsToDispose: Material[] = [];
+        const geometriesToDispose: BufferGeometry[] = [];
+
+        const registerTexture = (texture: Texture): Texture => {
+          texturesToDispose.push(texture);
+          return texture;
+        };
+
+        const registerMaterial = <T extends Material>(material: T): T => {
+          materialsToDispose.push(material);
+          return material;
+        };
+
+        const registerGeometry = <T extends BufferGeometry>(geometry: T): T => {
+          geometriesToDispose.push(geometry);
+          return geometry;
+        };
+
+        const createCanvasTexture = (
+          draw: (ctx: CanvasRenderingContext2D, size: number) => void
+        ): Texture => {
+          const size = 64;
+          const canvas = document.createElement("canvas");
+          canvas.width = size;
+          canvas.height = size;
+          const ctx = canvas.getContext("2d");
+          if (!ctx) {
+            throw new Error("Unable to acquire 2D context for textures");
+          }
+          ctx.imageSmoothingEnabled = false;
+          draw(ctx, size);
+          const texture = registerTexture(new THREE.CanvasTexture(canvas));
+          texture.magFilter = THREE.NearestFilter;
+          texture.minFilter = THREE.NearestMipMapNearestFilter;
+          texture.needsUpdate = true;
+          texture.colorSpace = THREE.SRGBColorSpace;
+          return texture;
+        };
+
+        const createNoise = (
+          ctx: CanvasRenderingContext2D,
+          size: number,
+          colors: string[],
+          density: number
+        ) => {
+          const cell = size / 8;
+          for (let i = 0; i < density; i += 1) {
+            const color = colors[i % colors.length];
+            ctx.fillStyle = color;
+            const x = Math.floor(Math.random() * size);
+            const y = Math.floor(Math.random() * size);
+            const w = cell * (Math.random() * 0.6 + 0.4);
+            const h = cell * (Math.random() * 0.6 + 0.4);
+            ctx.fillRect(x, y, w, h);
+          }
+        };
+
+        const createBlockMaterials = (): Record<BlockType, Material[]> => {
+          const grassTopTexture = createCanvasTexture((ctx, size) => {
+            ctx.fillStyle = "#45a142";
+            ctx.fillRect(0, 0, size, size);
+            createNoise(ctx, size, ["#3a8c36", "#2e6d28", "#51b64c"], 180);
+          });
+
+          const grassSideTexture = createCanvasTexture((ctx, size) => {
+            ctx.fillStyle = "#5a3c1e";
+            ctx.fillRect(0, 0, size, size);
+            ctx.fillStyle = "#3a8c36";
+            ctx.fillRect(0, 0, size, size * 0.32);
+            ctx.fillStyle = "#326e2d";
+            ctx.fillRect(0, size * 0.28, size, size * 0.05);
+            createNoise(ctx, size, ["rgba(53, 82, 31, 0.75)", "rgba(94, 61, 32, 0.6)"], 120);
+          });
+
+          const dirtTexture = createCanvasTexture((ctx, size) => {
+            ctx.fillStyle = "#6f4a2a";
+            ctx.fillRect(0, 0, size, size);
+            createNoise(ctx, size, ["#8c5c36", "#5b3b21", "#7a4f2d"], 160);
+          });
+
+          const stoneTexture = createCanvasTexture((ctx, size) => {
+            ctx.fillStyle = "#9da3a8";
+            ctx.fillRect(0, 0, size, size);
+            ctx.fillStyle = "#707579";
+            for (let i = 0; i < 40; i += 1) {
+              const w = size * (Math.random() * 0.25 + 0.05);
+              const h = size * (Math.random() * 0.25 + 0.05);
+              const x = Math.random() * (size - w);
+              const y = Math.random() * (size - h);
+              ctx.fillRect(x, y, w, h);
+            }
+          });
+
+          const sandTexture = createCanvasTexture((ctx, size) => {
+            ctx.fillStyle = "#e6d39a";
+            ctx.fillRect(0, 0, size, size);
+            createNoise(ctx, size, ["rgba(204, 176, 105, 0.7)", "rgba(232, 210, 155, 0.6)"], 140);
+          });
+
+          const logSideTexture = createCanvasTexture((ctx, size) => {
+            ctx.fillStyle = "#80562c";
+            ctx.fillRect(0, 0, size, size);
+            ctx.strokeStyle = "rgba(56, 33, 16, 0.6)";
+            ctx.lineWidth = size * 0.08;
+            for (let x = size * 0.15; x < size; x += size * 0.22) {
+              ctx.beginPath();
+              ctx.moveTo(x, 0);
+              ctx.lineTo(x, size);
+              ctx.stroke();
+            }
+          });
+
+          const logTopTexture = createCanvasTexture((ctx, size) => {
+            ctx.fillStyle = "#9b6b36";
+            ctx.fillRect(0, 0, size, size);
+            ctx.strokeStyle = "#5f3b1c";
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.arc(size / 2, size / 2, size * 0.28, 0, Math.PI * 2);
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.arc(size / 2, size / 2, size * 0.16, 0, Math.PI * 2);
+            ctx.stroke();
+          });
+
+          const leavesTexture = createCanvasTexture((ctx, size) => {
+            ctx.fillStyle = "rgba(74, 134, 46, 0.9)";
+            ctx.fillRect(0, 0, size, size);
+            createNoise(
+              ctx,
+              size,
+              ["rgba(99, 168, 62, 0.85)", "rgba(52, 102, 38, 0.8)", "rgba(123, 184, 79, 0.75)"],
+              200
+            );
+          });
+
+          const makeLambert = (texture: Texture) =>
+            registerMaterial(
+              new THREE.MeshLambertMaterial({
+                map: texture,
+              })
+            );
+
+          const fillWith = (material: Material): Material[] => [
+            material,
+            material,
+            material,
+            material,
+            material,
+            material,
+          ];
+
+          const grassTopMaterial = makeLambert(grassTopTexture);
+          const grassSideMaterial = makeLambert(grassSideTexture);
+          const grassBottomMaterial = makeLambert(dirtTexture);
+
+          const dirtMaterial = makeLambert(dirtTexture);
+          const stoneMaterial = makeLambert(stoneTexture);
+          const sandMaterial = makeLambert(sandTexture);
+
+          const logSideMaterial = makeLambert(logSideTexture);
+          const logTopMaterial = makeLambert(logTopTexture);
+
+          const leavesMaterial = registerMaterial(
+            new THREE.MeshLambertMaterial({
+              map: leavesTexture,
+              transparent: true,
+              opacity: 0.9,
+            })
+          );
+
+          const waterMaterial = registerMaterial(
+            new THREE.MeshPhongMaterial({
+              color: 0x2f7bff,
+              transparent: true,
+              opacity: 0.65,
+              shininess: 90,
+              specular: 0x9fc2ff,
+              side: THREE.DoubleSide,
+              depthWrite: false,
+            })
+          );
+
+          return {
+            grass: [
+              grassSideMaterial,
+              grassSideMaterial,
+              grassTopMaterial,
+              grassBottomMaterial,
+              grassSideMaterial,
+              grassSideMaterial,
+            ],
+            dirt: fillWith(dirtMaterial),
+            stone: fillWith(stoneMaterial),
+            sand: fillWith(sandMaterial),
+            water: fillWith(waterMaterial),
+            log: [
+              logSideMaterial,
+              logSideMaterial,
+              logTopMaterial,
+              logTopMaterial,
+              logSideMaterial,
+              logSideMaterial,
+            ],
+            leaves: fillWith(leavesMaterial),
+          } satisfies Record<BlockType, Material[]>;
+        };
+
+        const blockMaterials = createBlockMaterials();
+        const blockGeometry = registerGeometry(new THREE.BoxGeometry(1, 1, 1));
+        const highlightGeometry = registerGeometry(
+          new THREE.BoxGeometry(1.02, 1.02, 1.02)
+        );
+        const highlightMaterial = registerMaterial(
+          new THREE.MeshBasicMaterial({
+            color: 0xfff2a8,
+            wireframe: true,
+            transparent: true,
+            opacity: 0.85,
+            depthTest: false,
+          })
+        );
+        highlightMaterial.depthWrite = false;
+        const highlightMesh = new THREE.Mesh(highlightGeometry, highlightMaterial);
+        highlightMesh.visible = false;
+        scene.add(highlightMesh);
+
+        scene.add(new THREE.AmbientLight(0xffffff, 0.38));
+        scene.add(new THREE.HemisphereLight(0xd1ecff, 0x3c2f1a, 0.45));
+        const sun = new THREE.DirectionalLight(0xffffff, 0.78);
+        sun.position.set(60, 120, 40);
+        scene.add(sun);
+
+        const worldGroup = new THREE.Group();
+        scene.add(worldGroup);
+
+        const blocks = new Map<string, { mesh: Mesh; type: BlockType }>();
+
+        const addBlock = (x: number, y: number, z: number, type: BlockType) => {
+          const key = getBlockKey(x, y, z);
+          if (blocks.has(key)) {
+            return;
+          }
+          const mesh = new THREE.Mesh(blockGeometry, blockMaterials[type]);
+          mesh.position.set(x + 0.5, y + 0.5, z + 0.5);
+          worldGroup.add(mesh);
+          blocks.set(key, { mesh, type });
+          maxWorldHeight = Math.max(maxWorldHeight, y + 3);
+        };
+
+        const removeBlock = (x: number, y: number, z: number) => {
+          const key = getBlockKey(x, y, z);
+          const entry = blocks.get(key);
+          if (!entry) {
+            return;
+          }
+          worldGroup.remove(entry.mesh);
+          blocks.delete(key);
+        };
+
+        const getSurfaceHeight = (x: number, z: number): number => {
+          for (let y = Math.min(maxWorldHeight, MAX_BUILD_HEIGHT); y >= BASE_DEPTH - 1; y -= 1) {
+            const block = blocks.get(getBlockKey(x, y, z));
+            if (block && solidBlocks.has(block.type)) {
+              return y + 1;
+            }
+          }
+          return SEA_LEVEL + 1;
+        };
+
+        const pseudoRandom = (x: number, z: number): number => {
+          const seed = Math.sin(x * 12.9898 + z * 78.233) * 43758.5453123;
+          return seed - Math.floor(seed);
+        };
+
+        const sampleHeight = (x: number, z: number): number => {
+          const ridge = Math.sin(x / 5.8) * 2.2 + Math.cos(z / 6.4) * 1.8;
+          const swell = Math.sin((x + z) / 12.2) * 1.5;
+          const detail = Math.sin(Math.hypot(x, z) / 7.3) * 0.8;
+          const value = 2.2 + ridge + swell + detail;
+          return Math.max(1, Math.floor(value));
+        };
+
+        const plantTree = (x: number, surfaceY: number, z: number, variance: number) => {
+          const trunkHeight = 4 + Math.floor(variance * 3);
+          for (let i = 0; i < trunkHeight; i += 1) {
+            addBlock(x, surfaceY + i, z, "log");
+          }
+          const leafBase = surfaceY + trunkHeight - 2;
+          for (let lx = -2; lx <= 2; lx += 1) {
+            for (let lz = -2; lz <= 2; lz += 1) {
+              for (let ly = 0; ly <= 3; ly += 1) {
+                const distance = Math.abs(lx) + Math.abs(lz) + ly;
+                if (distance <= 4) {
+                  addBlock(x + lx, leafBase + ly, z + lz, "leaves");
+                }
+              }
+            }
+          }
+        };
+
+        for (let x = -WORLD_RADIUS; x <= WORLD_RADIUS; x += 1) {
+          for (let z = -WORLD_RADIUS; z <= WORLD_RADIUS; z += 1) {
+            addBlock(x, BASE_DEPTH, z, "stone");
+            addBlock(x, BASE_DEPTH - 1, z, "stone");
+            const height = sampleHeight(x, z);
+            const radial = Math.sqrt(x * x + z * z);
+            const coastLine = radial > WORLD_RADIUS - 5;
+            let surfaceType: BlockType = "grass";
+            for (let y = 0; y <= height; y += 1) {
+              let blockType: BlockType;
+              if (y === height) {
+                if (height <= SEA_LEVEL + (coastLine ? 1 : 0)) {
+                  blockType = "sand";
+                } else if (height >= SEA_LEVEL + 5) {
+                  blockType = "stone";
+                } else {
+                  blockType = coastLine ? "sand" : "grass";
+                }
+                surfaceType = blockType;
+              } else if (y >= height - 2) {
+                blockType = "dirt";
+              } else {
+                blockType = "stone";
+              }
+              addBlock(x, y, z, blockType);
+            }
+
+            if (height < SEA_LEVEL) {
+              for (let waterY = height + 1; waterY <= SEA_LEVEL; waterY += 1) {
+                addBlock(x, waterY, z, "water");
+              }
+              surfaceType = "water";
+            }
+
+            const treeChance = pseudoRandom(x, z);
+            if (
+              surfaceType === "grass" &&
+              height > SEA_LEVEL + 1 &&
+              radial < WORLD_RADIUS - 6 &&
+              treeChance > 0.86
+            ) {
+              plantTree(x, height + 1, z, pseudoRandom(x + 13.7, z + 91.3));
+            }
+          }
+        }
+
+        const spawnColumn = { x: 2, z: -(WORLD_RADIUS - 6) };
+        const spawnHeight = getSurfaceHeight(spawnColumn.x, spawnColumn.z);
+        controls.getObject().position.set(
+          spawnColumn.x + 0.5,
+          spawnHeight + PLAYER_EYE_HEIGHT,
+          spawnColumn.z + 0.5
+        );
+        camera.lookAt(new THREE.Vector3(0, SEA_LEVEL + 4, 0));
+
+        const moveState = {
+          forward: false,
+          backward: false,
+          left: false,
+          right: false,
+        };
+
+        const pickBlock = (): Intersection | undefined => {
+          raycaster.setFromCamera(pointer, camera);
+          const intersections = raycaster.intersectObjects(
+            worldGroup.children as Object3D[],
+            false
+          );
+          return intersections[0];
+        };
+
+        const updateHighlight = () => {
+          const hit = pickBlock();
+          if (hit) {
+            highlightMesh.visible = true;
+            highlightMesh.position.copy((hit.object as Mesh).position);
+          } else {
+            highlightMesh.visible = false;
+          }
+        };
+
+        const animate = () => {
+          const delta = clock.getDelta();
+          velocity.x -= velocity.x * DECELERATION * delta;
+          velocity.z -= velocity.z * DECELERATION * delta;
+
+          direction.set(0, 0, 0);
+          if (moveState.forward) direction.z -= 1;
+          if (moveState.backward) direction.z += 1;
+          if (moveState.left) direction.x -= 1;
+          if (moveState.right) direction.x += 1;
+          if (direction.lengthSq() > 0) {
+            direction.normalize();
+            velocity.x -= direction.x * MOVE_SPEED * delta;
+            velocity.z -= direction.z * MOVE_SPEED * delta;
+          }
+
+          const playerObject = controls.getObject();
+          previousPosition.copy(playerObject.position);
+
+          controls.moveRight(velocity.x * delta);
+          controls.moveForward(velocity.z * delta);
+
+          const currentX = Math.floor(playerObject.position.x);
+          const currentZ = Math.floor(playerObject.position.z);
+          const previousX = Math.floor(previousPosition.x);
+          const previousZ = Math.floor(previousPosition.z);
+
+          const nextSurface = getSurfaceHeight(currentX, currentZ);
+          const previousSurface = getSurfaceHeight(previousX, previousZ);
+
+          if (nextSurface - previousSurface > 1.25) {
+            playerObject.position.set(previousPosition.x, previousPosition.y, previousPosition.z);
+          }
+
+          const settledSurface = getSurfaceHeight(
+            Math.floor(playerObject.position.x),
+            Math.floor(playerObject.position.z)
+          );
+          playerObject.position.y = settledSurface + PLAYER_EYE_HEIGHT;
+
+          updateHighlight();
+          renderer.render(scene, camera);
+        };
+
+        renderer.setAnimationLoop(animate);
+
+        const onResize = () => {
+          if (!mountRef.current) {
+            return;
+          }
+          const { clientWidth, clientHeight } = mountRef.current;
+          camera.aspect = clientWidth / clientHeight;
+          camera.updateProjectionMatrix();
+          renderer.setSize(clientWidth, clientHeight, false);
+        };
+
+        const cycleSelection = (direction: number) => {
+          const currentIndex = SELECTABLE_BLOCKS.indexOf(selectedBlockRef.current);
+          const nextIndex =
+            (currentIndex + direction + SELECTABLE_BLOCKS.length) %
+            SELECTABLE_BLOCKS.length;
+          setBlockType(SELECTABLE_BLOCKS[nextIndex]);
+        };
+
+        const onKeyDown = (event: KeyboardEvent) => {
+          switch (event.code) {
+            case "KeyW":
+            case "ArrowUp":
+              moveState.forward = true;
+              break;
+            case "KeyS":
+            case "ArrowDown":
+              moveState.backward = true;
+              break;
+            case "KeyA":
+            case "ArrowLeft":
+              moveState.left = true;
+              break;
+            case "KeyD":
+            case "ArrowRight":
+              moveState.right = true;
+              break;
+            case "Digit1":
+            case "Digit2":
+            case "Digit3":
+            case "Digit4":
+            case "Digit5":
+            case "Digit6":
+            case "Digit7": {
+              const index = Number(event.code.replace("Digit", "")) - 1;
+              if (SELECTABLE_BLOCKS[index]) {
+                setBlockType(SELECTABLE_BLOCKS[index]);
+              }
+              break;
+            }
+            case "BracketLeft":
+              cycleSelection(-1);
+              break;
+            case "BracketRight":
+              cycleSelection(1);
+              break;
+            default:
+              break;
+          }
+        };
+
+        const onKeyUp = (event: KeyboardEvent) => {
+          switch (event.code) {
+            case "KeyW":
+            case "ArrowUp":
+              moveState.forward = false;
+              break;
+            case "KeyS":
+            case "ArrowDown":
+              moveState.backward = false;
+              break;
+            case "KeyA":
+            case "ArrowLeft":
+              moveState.left = false;
+              break;
+            case "KeyD":
+            case "ArrowRight":
+              moveState.right = false;
+              break;
+            default:
+              break;
+          }
+        };
+
+        const preventContextMenu = (event: MouseEvent) => {
+          event.preventDefault();
+        };
+
+        const addBlockFromHit = (hit: Intersection) => {
+          if (!hit.face) {
+            return;
+          }
+          const mesh = hit.object as Mesh;
+          const baseX = Math.floor(mesh.position.x);
+          const baseY = Math.floor(mesh.position.y);
+          const baseZ = Math.floor(mesh.position.z);
+          const normal = hit.face.normal;
+          const offsetX = normal.x > 0.5 ? 1 : normal.x < -0.5 ? -1 : 0;
+          const offsetY = normal.y > 0.5 ? 1 : normal.y < -0.5 ? -1 : 0;
+          const offsetZ = normal.z > 0.5 ? 1 : normal.z < -0.5 ? -1 : 0;
+          const targetX = baseX + offsetX;
+          const targetY = baseY + offsetY;
+          const targetZ = baseZ + offsetZ;
+          if (targetY > MAX_BUILD_HEIGHT) {
+            return;
+          }
+          const playerPosition = controls.getObject().position;
+          const distance = Math.sqrt(
+            (targetX + 0.5 - playerPosition.x) ** 2 +
+              (targetY + 0.5 - playerPosition.y) ** 2 +
+              (targetZ + 0.5 - playerPosition.z) ** 2
+          );
+          if (distance < 1.8) {
+            return;
+          }
+          addBlock(targetX, targetY, targetZ, selectedBlockRef.current);
+        };
+
+        const removeBlockFromHit = (hit: Intersection) => {
+          const mesh = hit.object as Mesh;
+          const x = Math.floor(mesh.position.x);
+          const y = Math.floor(mesh.position.y);
+          const z = Math.floor(mesh.position.z);
+          if (y <= BASE_DEPTH) {
+            return;
+          }
+          removeBlock(x, y, z);
+        };
+
+        const onMouseDown = (event: MouseEvent) => {
+          if (!controls.isLocked) {
+            controls.lock();
+            return;
+          }
+
+          if (event.button === 0) {
+            const hit = pickBlock();
+            if (hit) {
+              removeBlockFromHit(hit);
+            }
+          } else if (event.button === 2) {
+            event.preventDefault();
+            const hit = pickBlock();
+            if (hit) {
+              addBlockFromHit(hit);
+            }
+          } else if (event.button === 1) {
+            event.preventDefault();
+            cycleSelection(1);
+          }
+        };
+
+        const onWheel = (event: WheelEvent) => {
+          if (event.deltaY === 0) {
+            return;
+          }
+          event.preventDefault();
+          cycleSelection(event.deltaY > 0 ? 1 : -1);
+        };
+
+        const handleLock = () => {
+          if (!active) {
+            return;
+          }
+          setIsLocked(true);
+        };
+
+        const handleUnlock = () => {
+          if (!active) {
+            return;
+          }
+          setIsLocked(false);
+          updateHighlight();
+        };
+
+        controls.addEventListener("lock", handleLock);
+        controls.addEventListener("unlock", handleUnlock);
+
+        window.addEventListener("resize", onResize);
+        window.addEventListener("keydown", onKeyDown);
+        window.addEventListener("keyup", onKeyUp);
+        renderer.domElement.addEventListener("mousedown", onMouseDown);
+        renderer.domElement.addEventListener("wheel", onWheel, { passive: false });
+        renderer.domElement.addEventListener("contextmenu", preventContextMenu);
+
+        updateHighlight();
+
+        cleanup = () => {
+          controls.removeEventListener("lock", handleLock);
+          controls.removeEventListener("unlock", handleUnlock);
+          window.removeEventListener("resize", onResize);
+          window.removeEventListener("keydown", onKeyDown);
+          window.removeEventListener("keyup", onKeyUp);
+          renderer.domElement.removeEventListener("mousedown", onMouseDown);
+          renderer.domElement.removeEventListener("wheel", onWheel);
+          renderer.domElement.removeEventListener("contextmenu", preventContextMenu);
+          renderer.setAnimationLoop(null);
+          renderer.dispose();
+          controls.disconnect();
+          controls.unlock();
+          if (renderer.domElement.parentElement === mountElement) {
+            mountElement.removeChild(renderer.domElement);
+          }
+          worldGroup.clear();
+          highlightMesh.removeFromParent();
+          geometriesToDispose.forEach((geometry) => geometry.dispose());
+          materialsToDispose.forEach((material) => material.dispose());
+          texturesToDispose.forEach((texture) => texture.dispose());
+        };
+      } catch (err) {
+        if (!active) {
+          return;
+        }
+        const message =
+          err instanceof Error
+            ? err.message
+            : "Failed to load the 3D engine. Please check your connection.";
+        setError(message);
+      }
+    };
+
+    setup();
+
+    return () => {
+      active = false;
+      if (cleanup) {
+        cleanup();
+      }
+    };
+  }, [setBlockType]);
+
+  const instructionsClassName = `${styles.instructions} ${
+    isLocked ? styles.instructionsHidden : ""
+  }`;
+
+  return (
+    <div className={styles.page}>
+      <div ref={mountRef} className={styles.canvasRoot} />
+      <div className={styles.hud}>
+        <div className={styles.crosshair} aria-hidden="true">
+          +
+        </div>
+      </div>
+      <div className={styles.inventory}>
+        {SELECTABLE_BLOCKS.map((type, index) => {
+          const isSelected = selectedBlock === type;
+          return (
+            <button
+              key={type}
+              type="button"
+              className={`${styles.slotButton} ${
+                isSelected ? styles.slotSelected : ""
+              }`}
+              aria-pressed={isSelected}
+              onClick={() => setBlockType(type)}
+            >
+              <span
+                className={styles.blockSwatch}
+                style={{ background: BLOCK_SWATCHES[type] }}
+                aria-hidden="true"
+              />
+              <span>{`${index + 1}. ${BLOCK_LABELS[type]}`}</span>
+            </button>
+          );
+        })}
+      </div>
+      <div className={instructionsClassName}>
+        <h1>BlazeCraft Prototype</h1>
+        <p>Click the world to capture your cursor and explore.</p>
+        <ul>
+          <li>WASD / Arrow keys &mdash; Move</li>
+          <li>Mouse &mdash; Look around</li>
+          <li>Left click &mdash; Mine block</li>
+          <li>Right click &mdash; Place selected block</li>
+          <li>Scroll wheel or keys 1-7 &mdash; Change block type</li>
+          <li>Middle click &mdash; Cycle palette</li>
+          <li>Esc &mdash; Release cursor</li>
+        </ul>
+      </div>
+      {error ? <div className={styles.errorBanner}>{error}</div> : null}
+    </div>
+  );
+};
+
+export default MinecraftPage;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,9 @@ const Home = () => {
     <main className={styles.main}>
       <div className={styles.title}>Blaze Intelligence Research Portal</div>
       <div className={styles.container}>
+        <a className={styles.category} href="/minecraft">
+          BlazeCraft Prototype
+        </a>
         {sportsCategories.map((cat) => (
           <a key={cat.id} className={styles.category} href={`/sports/${cat.id}`}>
             {cat.name}

--- a/types/three-externals.d.ts
+++ b/types/three-externals.d.ts
@@ -1,0 +1,212 @@
+declare module "three" {
+  export class Color {
+    constructor(color?: number | string);
+    set(color: number | string): this;
+  }
+
+  export class Fog {
+    constructor(color: number | string, near?: number, far?: number);
+  }
+
+  export class Vector2 {
+    constructor(x?: number, y?: number);
+    x: number;
+    y: number;
+    set(x: number, y: number): this;
+  }
+
+  export class Vector3 {
+    constructor(x?: number, y?: number, z?: number);
+    x: number;
+    y: number;
+    z: number;
+    set(x: number, y: number, z: number): this;
+    setScalar(value: number): this;
+    add(v: Vector3): this;
+    sub(v: Vector3): this;
+    copy(v: Vector3): this;
+    clone(): Vector3;
+    length(): number;
+    lengthSq(): number;
+    normalize(): this;
+    multiplyScalar(value: number): this;
+  }
+
+  export class Object3D {
+    readonly position: Vector3;
+    visible: boolean;
+    readonly children: Object3D[];
+    add(...objects: Object3D[]): this;
+    remove(...objects: Object3D[]): this;
+    removeFromParent(): this;
+  }
+
+  export class Group extends Object3D {
+    clear(): this;
+  }
+
+  export class Camera extends Object3D {}
+
+  export class PerspectiveCamera extends Camera {
+    constructor(fov?: number, aspect?: number, near?: number, far?: number);
+    aspect: number;
+    updateProjectionMatrix(): void;
+    lookAt(x: number | Vector3, y?: number, z?: number): void;
+  }
+
+  export interface WebGLRendererParameters {
+    antialias?: boolean;
+    alpha?: boolean;
+  }
+
+  export class WebGLRenderer {
+    constructor(parameters?: WebGLRendererParameters);
+    domElement: HTMLCanvasElement;
+    outputColorSpace: string;
+    setPixelRatio(value: number): void;
+    setSize(width: number, height: number, updateStyle?: boolean): void;
+    render(scene: Scene, camera: Camera): void;
+    dispose(): void;
+    setAnimationLoop(callback: ((time: number) => void) | null): void;
+  }
+
+  export class Scene extends Object3D {
+    background: Color | null;
+    fog: Fog | null;
+  }
+
+  export class Clock {
+    constructor(autoStart?: boolean);
+    getDelta(): number;
+  }
+
+  export class Texture {
+    magFilter: number;
+    minFilter: number;
+    needsUpdate: boolean;
+    colorSpace: string;
+    dispose(): void;
+  }
+
+  export class CanvasTexture extends Texture {
+    constructor(canvas: HTMLCanvasElement);
+  }
+
+  export class BufferGeometry {
+    dispose(): void;
+  }
+
+  export class BoxGeometry extends BufferGeometry {
+    constructor(width?: number, height?: number, depth?: number);
+  }
+
+  export class Material {
+    transparent?: boolean;
+    opacity?: number;
+    dispose(): void;
+  }
+
+  export interface MeshBasicMaterialParameters {
+    color?: number | string;
+    wireframe?: boolean;
+    transparent?: boolean;
+    opacity?: number;
+    depthTest?: boolean;
+    depthWrite?: boolean;
+  }
+
+  export class MeshBasicMaterial extends Material {
+    constructor(parameters?: MeshBasicMaterialParameters);
+    color: Color;
+    wireframe: boolean;
+    depthWrite: boolean;
+  }
+
+  export interface MeshLambertMaterialParameters {
+    map?: Texture;
+    transparent?: boolean;
+    opacity?: number;
+  }
+
+  export class MeshLambertMaterial extends Material {
+    constructor(parameters?: MeshLambertMaterialParameters);
+    map?: Texture;
+  }
+
+  export interface MeshPhongMaterialParameters {
+    color?: number | string;
+    transparent?: boolean;
+    opacity?: number;
+    shininess?: number;
+    specular?: number | string;
+    side?: number;
+    depthWrite?: boolean;
+  }
+
+  export class MeshPhongMaterial extends Material {
+    constructor(parameters?: MeshPhongMaterialParameters);
+  }
+
+  export class Mesh<TGeometry extends BufferGeometry = BufferGeometry, TMaterial extends Material | Material[] = Material | Material[]> extends Object3D {
+    constructor(geometry?: TGeometry, material?: TMaterial);
+    geometry: TGeometry;
+    material: TMaterial;
+  }
+
+  export class Light extends Object3D {
+    intensity: number;
+    color: Color;
+  }
+
+  export class AmbientLight extends Light {
+    constructor(color?: number | string, intensity?: number);
+  }
+
+  export class DirectionalLight extends Light {
+    constructor(color?: number | string, intensity?: number);
+  }
+
+  export class HemisphereLight extends Light {
+    constructor(skyColor?: number | string, groundColor?: number | string, intensity?: number);
+  }
+
+  export interface Intersection {
+    distance: number;
+    point: Vector3;
+    object: Object3D;
+    face?: { normal: Vector3 };
+  }
+
+  export class Raycaster {
+    constructor(origin?: Vector3, direction?: Vector3, near?: number, far?: number);
+    setFromCamera(coords: Vector2, camera: Camera): void;
+    intersectObjects(objects: Object3D[], recursive?: boolean): Intersection[];
+  }
+
+  export const NearestFilter: number;
+  export const NearestMipMapNearestFilter: number;
+  export const DoubleSide: number;
+  export const SRGBColorSpace: string;
+}
+
+declare module "three/examples/jsm/controls/PointerLockControls" {
+  import type { Camera, Object3D } from "three";
+
+  export class EventDispatcher<TEvents extends string = string> {
+    addEventListener(type: TEvents, listener: (...args: unknown[]) => void): void;
+    removeEventListener(type: TEvents, listener: (...args: unknown[]) => void): void;
+  }
+
+  export class PointerLockControls extends EventDispatcher<"lock" | "unlock"> {
+    constructor(camera: Camera, domElement?: HTMLElement);
+    readonly isLocked: boolean;
+    domElement: HTMLElement;
+    connect(): void;
+    disconnect(): void;
+    lock(): void;
+    unlock(): void;
+    getObject(): Object3D;
+    moveForward(distance: number): void;
+    moveRight(distance: number): void;
+  }
+}


### PR DESCRIPTION
## Summary
- add a `/minecraft` client route that streams three.js from a CDN and bootstraps a basic Minecraft-style sandbox with block placement/removal
- render custom procedurally generated textures plus sand, water, and tree biomes with HUD instructions and inventory styling
- document required three.js types locally and expose the demo entry point from the home page

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68d076a46f9083309c63f2608ca3d9ce